### PR TITLE
Add repo intelligence metadata, health checks, and CI preflight tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Added
+### Added (Unreleased)
+
 - C# symbol extraction in `codeindex symbols` (`.cs`): Roslyn-first via optional `codeindex-csharp-symbols`, with built-in regex fallback
+- Schema, freshness, tool version, analyzer mode, extractor, and confidence metadata in generated indexes
+- `get_symbol_metadata` MCP tool for agent-facing symbol provenance and confidence inspection
+- `codeindex doctor` CLI command and `verify_repo_health` MCP tool for index health, freshness, schema, and diagnostics checks
+- `codeindex ci` CLI command and `run_ci_check` MCP tool for PR/CI preflight checks over index health and changed-file blast radius
+- Reference docs for index schemas, analyzer modes, MCP tools, troubleshooting, and AI agent workflows
+- Fixture-backed regression coverage for symbol provenance, confidence bands, legacy index warnings, and CI warning policy
 
 ## [0.2.0] - 2026-05-24
 
-### Added
+### Added (0.2.0)
+
 - `codeindex lookup <symbol>` — find where a symbol is defined (file + line)
 - `codeindex dependencies <file>` — show imports and imported-by for a file
 - `codeindex high-blast` — list files above a blast score threshold
@@ -18,18 +26,21 @@ All notable changes to this project will be documented in this file.
 - CLI integration test suite (`benchmark/test_cli.py`) — 37 assertions covering happy path, `--json` output, error cases, and sort-order invariants
 - MCP server integration test suite (`benchmark/test_mcp.py`) — all 6 MCP tools tested via real JSON-RPC stdio
 
-### Changed
+### Changed (0.2.0)
+
 - MCP tests made repo-agnostic via fixture discovery from live index files
 - `--claude-md` symbol section wrapped in `symbolindex` code fence
 
-### Docs
+### Docs (0.2.0)
+
 - Claude coding workflows section in README
 - `lookup`, `dependencies`, and `high-blast` CLI command documentation
 - MCP registration instructions corrected to use `claude mcp add`
 
 ## [0.1.0] - Initial release
 
-### Added
+### Added (0.1.0)
+
 - Multi-language dependency analysis: Python, JavaScript/TypeScript, Go, Ruby, Rust, Java/Kotlin, PHP, CSS
 - Blast-radius impact scoring — every file gets a score based on direct and transitive dependents
 - `codeindex analyze <repo>` — analyze a repo and write `codeindex.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- C# symbol extraction in `codeindex symbols` (`.cs`): Roslyn-first via optional `codeindex-csharp-symbols`, with built-in regex fallback
+
 ## [0.2.0] - 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ codeindex impact src/auth.py
 | Ruby | `require`, `require_relative`, `autoload` | Classes, modules, methods |
 | Rust | `mod`, `use crate::` | `pub fn`, structs, enums, traits |
 | Java / Kotlin | FQN imports, wildcard imports | Classes, interfaces, methods |
+| C# | — | Roslyn-first extraction via `codeindex-csharp-symbols` (if installed), regex fallback for types/methods |
 | PHP | PSR-4 namespace resolution | Classes, interfaces, functions |
 | CSS / SCSS / Less | `@import`, `@use`, `@forward` | — |
 | Docker | Services, `depends_on` edges | — |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Point it at any project — Python, JavaScript/TypeScript, Go, Ruby, Rust, Java,
 - A `codeindex.json` dependency index written directly into your repo
 - Per-file blast-radius scores (how many files break if this one changes)
 - A `symbolindex.json` symbol map so AI can find any function/class without scanning every file
+- Trust metadata for symbol extraction: schema version, extractor, analysis mode, confidence, and generation time
 - Five ways to consume the data: CLI, markdown report, MCP server, pre-commit hook, CLAUDE.md injection
 - An interactive visualization UI (2D/3D graphs, dependency matrix, treemap)
 
@@ -42,6 +43,12 @@ codeindex symbols ./myapp
 # See blast radius for a file before touching it
 codeindex impact src/auth.py
 
+# Check index health, freshness, and trust metadata
+codeindex doctor ./myapp
+
+# Run a PR/CI preflight against changed files
+codeindex ci ./myapp --base origin/main
+
 # Launch the visualization UI
 codeindex serve --viz --repo ./myapp
 open http://localhost:8080
@@ -60,7 +67,7 @@ codeindex analyze [REPO_PATH] [--output PATH] [--watch]
 Analyzes the repo and writes `codeindex.json` to the repo root. Detects 12+ languages automatically.
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| ---- | ------- | ----------- |
 | `REPO_PATH` | `.` | Path to repo root |
 | `--output` | `<repo>/codeindex.json` | Override output path |
 | `--watch` | off | Re-index on file changes (requires `watchdog`) |
@@ -76,10 +83,12 @@ codeindex symbols [REPO_PATH] [--output PATH] [--inline] [--index PATH]
 
 Builds a symbol index — a map of every function, class, struct, and type to its exact file and line number. Lets AI tools (and humans) find any symbol in one lookup instead of scanning the entire repo.
 
+Symbol entries include provenance metadata such as `analysisMode`, `extractor`, and `confidence`. This lets humans and agents distinguish parser/compiler-backed results from regex fallbacks, with benchmark fixtures guarding the current language confidence bands.
+
 **Modes:**
 
 | Flag | Description |
-|------|-------------|
+| ---- | ----------- |
 | _(none)_ | Write a standalone `symbolindex.json` |
 | `--inline` | Embed symbols into each node in `codeindex.json` instead |
 | `--claude-md` | Append a compressed symbol summary to `CLAUDE.md` |
@@ -89,7 +98,7 @@ Both `--inline` and `--claude-md` can be combined in a single run.
 **Options:**
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| ---- | ------- | ----------- |
 | `REPO_PATH` | `.` | Path to repo root |
 | `--output` | `<repo>/symbolindex.json` | Output path (standalone mode) |
 | `--index` | auto-discovered | Path to `codeindex.json` (for `--inline`) |
@@ -129,7 +138,7 @@ codeindex impact FILE [--index PATH] [--out FILE] [--json]
 
 Shows the blast-radius impact for a specific file: direct dependents, transitive dependents, blast score, and risk level.
 
-```
+```text
 Impact: src/auth.py
 Blast Score: 8.5  (2 direct · 7 transitive)  [HIGH]
 
@@ -148,7 +157,7 @@ Risk: HIGH — affects 7/42 files (16.7% of codebase)
 **Blast score formula:** `direct + (0.5 × transitive)`
 
 | Flag | Description |
-|------|-------------|
+| ---- | ----------- |
 | `--index PATH` | Path to `codeindex.json` (auto-discovered if omitted) |
 | `--out FILE` | Write a markdown report to this file |
 | `--json` | Output raw JSON |
@@ -169,13 +178,16 @@ codeindex serve --mcp
 **MCP tools:**
 
 | Tool | Description |
-|------|-------------|
+| ---- | ----------- |
 | `analyze_repo` | Build or refresh the dependency index |
 | `get_impact` | Blast-radius report for a file |
 | `get_dependencies` | imports + imported-by for a file |
 | `get_high_blast_files` | All files above a blast score threshold |
 | `build_symbol_index` | Build or refresh the symbol index |
 | `lookup_symbol` | Find where any function/class/type is defined (file + line) |
+| `get_symbol_metadata` | Inspect symbol extraction mode, extractor, and confidence |
+| `verify_repo_health` | Check index presence, schema metadata, freshness, and diagnostics |
+| `run_ci_check` | Run index health plus changed-file blast checks for PR/CI workflows |
 
 **Claude Code MCP config** (`.claude/settings.json`):
 
@@ -200,7 +212,7 @@ codeindex lookup SYMBOL [--index PATH] [--json]
 
 Finds where a function, class, struct, or other symbol is defined. O(1) lookup against `symbolindex.json` — no file scanning.
 
-```
+```text
 $ codeindex lookup compute_blast_radius
 codeindex/impact.py:6  (function)
 
@@ -209,7 +221,7 @@ src/auth.py:44  (class)  methods: login, logout, refresh
 ```
 
 | Flag | Description |
-|------|-------------|
+| ---- | ----------- |
 | `--index PATH` | Path to `symbolindex.json` (auto-discovered if omitted) |
 | `--json` | Output raw JSON |
 
@@ -223,7 +235,7 @@ codeindex dependencies FILE [--index PATH] [--json]
 
 Shows what a file imports and what imports it, plus its blast score.
 
-```
+```text
 $ codeindex dependencies src/auth.py
 File: src/auth.py  (blast score: 8.5)
 
@@ -238,7 +250,7 @@ Imported by (2):
 ```
 
 | Flag | Description |
-|------|-------------|
+| ---- | ----------- |
 | `--index PATH` | Path to `codeindex.json` (auto-discovered if omitted) |
 | `--json` | Output raw JSON |
 
@@ -252,7 +264,7 @@ codeindex high-blast [--threshold N] [--index PATH] [--json]
 
 Lists all files whose blast score exceeds the threshold, sorted by score descending. Useful for identifying the riskiest files before a refactor.
 
-```
+```text
 $ codeindex high-blast --threshold 5
 Files with blast score ≥ 5.0  (3 found)
 
@@ -264,9 +276,52 @@ Files with blast score ≥ 5.0  (3 found)
 `d` = direct dependents · `t` = transitive dependents
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| ---- | ------- | ----------- |
 | `--threshold N` | `5` | Minimum blast score to include |
 | `--index PATH` | auto-discovered | Path to `codeindex.json` |
+| `--json` | off | Output raw JSON |
+
+---
+
+### `codeindex doctor`
+
+```bash
+codeindex doctor [REPO_PATH] [--index PATH] [--symbol-index PATH]
+                 [--max-age-days N] [--json]
+```
+
+Checks whether generated indexes exist, include schema and freshness metadata, and report diagnostics. Use this before wiring codeindex into CI or agent workflows.
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `REPO_PATH` | `.` | Path to repo root |
+| `--index` | `<repo>/codeindex.json` | Override dependency index path |
+| `--symbol-index` | `<repo>/symbolindex.json` | Override symbol index path |
+| `--max-age-days` | `7` | Warn when indexes are older than this many days |
+| `--json` | off | Output raw JSON |
+
+---
+
+### `codeindex ci`
+
+```bash
+codeindex ci [REPO_PATH] [--base REF] [--index PATH] [--symbol-index PATH]
+             [--max-age-days N] [--blast-threshold N]
+             [--include-untracked] [--strict] [--json]
+```
+
+Runs a CI-friendly preflight: `doctor` health checks plus changed-file blast-radius warnings. By default, warnings do not fail the command. Add `--strict` when a team is ready to make stale indexes or high-blast changes block a PR.
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `REPO_PATH` | `.` | Path to repo root |
+| `--base REF` | local staged/unstaged diff | Compare committed changes against a PR base such as `origin/main` |
+| `--index` | `<repo>/codeindex.json` | Override dependency index path |
+| `--symbol-index` | `<repo>/symbolindex.json` | Override symbol index path |
+| `--max-age-days` | `7` | Warn when indexes are older than this many days |
+| `--blast-threshold N` | `10` | Warn when changed files meet or exceed this blast score |
+| `--include-untracked` | off | Include untracked files in local changed-file checks |
+| `--strict` | off | Exit non-zero when warnings are present |
 | `--json` | off | Output raw JSON |
 
 ---
@@ -280,7 +335,7 @@ codeindex install-hook [--repo PATH] [--threshold N] [--strict] [--remove]
 Installs a git pre-commit hook that warns when staged files exceed the blast score threshold.
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| ---- | ------- | ----------- |
 | `--threshold N` | `10` | Blast score above which to warn |
 | `--strict` | off | Block the commit instead of just warning |
 | `--remove` | — | Uninstall the hook |
@@ -296,6 +351,7 @@ Three workflows, ordered by automation level.
 Claude gets symbol lookup, dependency, and impact tools it calls automatically. No extra prompting needed.
 
 **One-time setup:**
+
 ```bash
 cd /your/other/repo
 codeindex analyze .
@@ -320,15 +376,17 @@ claude mcp add --scope project codeindex -- /opt/homebrew/Caskroom/miniforge/bas
 ```
 
 Verify it registered:
+
 ```bash
 claude mcp list
 ```
 
 > **Note:** Do not use `"command": "codeindex"` with a bare name — Claude Code does not inherit your shell PATH, so the binary won't be found unless you use the absolute path.
 
-Claude now has all 6 MCP tools available in every session. When it needs to find `processPayment`, it calls `lookup_symbol("processPayment")` and gets `src/billing.py:142` back in one shot — no file scanning.
+Claude now has all 9 MCP tools available in every session. When it needs to find `processPayment`, it calls `lookup_symbol("processPayment")` and gets `src/billing.py:142` plus provenance metadata back in one shot — no file scanning.
 
 **Keep the index fresh:**
+
 ```bash
 # Auto-rebuild on file changes (leave running in a terminal)
 codeindex symbols . --watch
@@ -350,6 +408,7 @@ This upserts a `symbolindex` code fence into `CLAUDE.md`. Every Claude Code sess
 **Tradeoff:** adds ~500–2000 tokens to every prompt depending on repo size. Worth it for repos where symbol lookups are frequent; skip it for repos where you mostly write new code.
 
 **Keep it fresh:**
+
 ```bash
 # Re-run after significant refactors
 codeindex analyze . && codeindex symbols . --claude-md
@@ -367,6 +426,7 @@ codeindex symbols .
 ```
 
 Then add to `CLAUDE.md`:
+
 ```markdown
 ## Codeindex
 Symbol index: `symbolindex.json` — use the `lookup_symbol` MCP tool before grepping for any function or class.
@@ -401,7 +461,7 @@ codeindex impact src/auth.py
 ### Which workflow to pick
 
 | Situation | Workflow |
-|-----------|----------|
+| --------- | -------- |
 | Daily driver repo, active feature work | MCP server |
 | Medium repo, frequent symbol lookups | CLAUDE.md injection |
 | Large repo (1000+ files) | MCP server + short CLAUDE.md hint |
@@ -413,7 +473,7 @@ codeindex impact src/auth.py
 ## Supported Languages
 
 | Language | Dependency analysis | Symbol extraction |
-|----------|--------------------|--------------------|
+| -------- | ------------------- | ----------------- |
 | Python | AST imports, type detection | Functions, classes, methods (AST-precise) |
 | JavaScript / TypeScript | ES modules, `require()`, framework detection | Exported functions, classes, types, enums, consts |
 | Vue | SFC `<script>` imports | Exported symbols from `<script>` block |
@@ -421,7 +481,7 @@ codeindex impact src/auth.py
 | Ruby | `require`, `require_relative`, `autoload` | Classes, modules, methods |
 | Rust | `mod`, `use crate::` | `pub fn`, structs, enums, traits |
 | Java / Kotlin | FQN imports, wildcard imports | Classes, interfaces, methods |
-| C# | — | Roslyn-first extraction via `codeindex-csharp-symbols` (if installed), regex fallback for types/methods |
+| C# | — | Roslyn-first extraction via `codeindex-csharp-symbols` (if installed), visible regex fallback for types/methods |
 | PHP | PSR-4 namespace resolution | Classes, interfaces, functions |
 | CSS / SCSS / Less | `@import`, `@use`, `@forward` | — |
 | Docker | Services, `depends_on` edges | — |
@@ -436,11 +496,16 @@ codeindex impact src/auth.py
 
 ```json
 {
+  "schemaVersion": 1,
   "meta": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-05-30T12:00:00Z",
+    "toolVersion": "0.2.0",
     "root": "myapp/",
     "total_files": 60,
     "total_loc": 4085,
-    "languages": ["python", "javascript"]
+    "languages": ["python", "javascript"],
+    "diagnostics": []
   },
   "nodes": [
     {
@@ -455,9 +520,11 @@ codeindex impact src/auth.py
       "transitive_dependents": 7,
       "blast_score": 5.5,
       "symbols": [
-        { "name": "verify_token", "line": 18, "kind": "function", "exported": true },
+        { "name": "verify_token", "line": 18, "kind": "function", "exported": true,
+          "analysisMode": "ast", "extractor": "python-ast", "confidence": 0.95 },
         { "name": "AuthService",  "line": 44, "kind": "class",    "exported": true,
-          "methods": ["login", "logout", "refresh"] }
+          "methods": ["login", "logout", "refresh"],
+          "analysisMode": "ast", "extractor": "python-ast", "confidence": 0.95 }
       ]
     }
   ],
@@ -475,10 +542,17 @@ The `symbols` field is only present when `codeindex symbols --inline` has been r
 
 ```json
 {
+  "schemaVersion": 1,
   "meta": {
+    "schemaVersion": 1,
     "generated": "2026-05-21",
+    "generatedAt": "2026-05-21T12:00:00Z",
     "repo": "myapp/",
-    "total_symbols": 312
+    "total_symbols": 312,
+    "toolVersion": "0.2.0",
+    "analysisModes": { "python": { "ast": 312 } },
+    "confidence": { "average": 0.95, "bands": { "high": 312, "medium": 0, "low": 0 } },
+    "diagnostics": []
   },
   "symbols": {
     "verify_token": [
@@ -487,7 +561,12 @@ The `symbols` field is only present when `codeindex symbols --inline` has been r
         "line": 18,
         "kind": "function",
         "exported": true,
-        "doc": "Verify a JWT and return the decoded payload."
+        "doc": "Verify a JWT and return the decoded payload.",
+        "analysisMode": "ast",
+        "extractor": "python-ast",
+        "extractorVersion": "1",
+        "confidence": 0.95,
+        "schemaVersion": 1
       }
     ],
     "AuthService": [
@@ -496,15 +575,22 @@ The `symbols` field is only present when `codeindex symbols --inline` has been r
         "line": 44,
         "kind": "class",
         "exported": true,
-        "methods": ["login", "logout", "refresh"]
+        "methods": ["login", "logout", "refresh"],
+        "analysisMode": "ast",
+        "extractor": "python-ast",
+        "extractorVersion": "1",
+        "confidence": 0.95,
+        "schemaVersion": 1
       }
     ]
   },
   "file_symbols": {
     "src/auth.py": [
-      { "name": "verify_token", "line": 18, "kind": "function", "exported": true },
+      { "name": "verify_token", "line": 18, "kind": "function", "exported": true,
+        "analysisMode": "ast", "extractor": "python-ast", "confidence": 0.95 },
       { "name": "AuthService",  "line": 44, "kind": "class",    "exported": true,
-        "methods": ["login", "logout", "refresh"] }
+        "methods": ["login", "logout", "refresh"],
+        "analysisMode": "ast", "extractor": "python-ast", "confidence": 0.95 }
     ]
   }
 }
@@ -512,9 +598,11 @@ The `symbols` field is only present when `codeindex symbols --inline` has been r
 
 **Lookup patterns:**
 
-- *"Where is `verify_token` defined?"* → `symbols["verify_token"][0].file` + `.line` — O(1)
-- *"What symbols live in `src/auth.py`?"* → `file_symbols["src/auth.py"]` — O(1)
-- *"What's the blast radius of changing `verify_token`?"* → cross-reference `codeindex.json` via the file
+- _"Where is `verify_token` defined?"_ → `symbols["verify_token"][0].file` + `.line` — O(1)
+- _"What symbols live in `src/auth.py`?"_ → `file_symbols["src/auth.py"]` — O(1)
+- _"What's the blast radius of changing `verify_token`?"_ → cross-reference `codeindex.json` via the file
+
+Trust fields are documented in [docs/reference/symbolindex-schema.md](docs/reference/symbolindex-schema.md) and [docs/reference/analyzer-modes.md](docs/reference/analyzer-modes.md). Treat high-confidence `ast` or `roslyn` results as stronger navigation evidence than medium-confidence `regex` results.
 
 ---
 
@@ -522,7 +610,7 @@ The `symbols` field is only present when `codeindex symbols --inline` has been r
 
 When `--claude-md` is used, a compact section is upserted into `CLAUDE.md` bounded by HTML comment markers so re-runs update in place:
 
-```
+````markdown
 <!-- codeindex-symbols-start -->
 ## Symbol Index
 _Generated by codeindex. Update: `codeindex symbols --claude-md`_
@@ -532,7 +620,7 @@ src/auth.py: verify_token:fn:18 AuthService:cls:44[login,logout,refresh]
 src/db.py: connect:fn:12 query:fn:28 close:fn:55
 ```
 <!-- codeindex-symbols-end -->
-```
+````
 
 Format per symbol: `name:kind_abbr:line[methods...]`
 Kind abbreviations: `fn` function · `cls` class · `st` struct · `en` enum · `tr` trait · `if` interface · `ty` type · `co` const
@@ -542,7 +630,7 @@ Kind abbreviations: `fn` function · `cls` class · `st` struct · `en` enum · 
 ## AI workflow comparison
 
 | Task | Without codeindex | With symbolindex.json |
-|------|-------------------|----------------------|
+| ---- | ----------------- | --------------------- |
 | Find where `process_payment` is defined | Grep / scan ~200 files | Load 1 file, O(1) lookup |
 | Understand blast radius of a change | Manual tracing | `codeindex impact <file>` |
 | Load only relevant context | Full repo scan | File + line from symbol map |
@@ -553,10 +641,23 @@ Kind abbreviations: `fn` function · `cls` class · `st` struct · `en` enum · 
 ## Optional dependencies
 
 | Package | Purpose | Install |
-|---------|---------|---------|
+| ------- | ------- | ------- |
 | `watchdog` | `--watch` file change detection | `pip install 'codeindex[watch]'` |
 | `PyYAML` | Better Docker Compose / CI YAML parsing | `pip install 'codeindex[yaml]'` |
 | `tomli` | Rust `Cargo.toml` on Python < 3.11 | `pip install 'codeindex[toml]'` |
+
+---
+
+## Documentation
+
+| Topic | File |
+| ----- | ---- |
+| `codeindex.json` schema | [docs/reference/codeindex-schema.md](docs/reference/codeindex-schema.md) |
+| `symbolindex.json` schema | [docs/reference/symbolindex-schema.md](docs/reference/symbolindex-schema.md) |
+| Analyzer modes and confidence | [docs/reference/analyzer-modes.md](docs/reference/analyzer-modes.md) |
+| MCP tools | [docs/reference/mcp-tools.md](docs/reference/mcp-tools.md) |
+| AI agent workflows | [docs/workflows/ai-agent-workflows.md](docs/workflows/ai-agent-workflows.md) |
+| Troubleshooting | [docs/operations/troubleshooting.md](docs/operations/troubleshooting.md) |
 
 ---
 

--- a/benchmark/fixtures/expected/ci_policy.json
+++ b/benchmark/fixtures/expected/ci_policy.json
@@ -1,0 +1,14 @@
+{
+  "nonStrictWarnings": {
+    "ok": true,
+    "status": "warning"
+  },
+  "strictWarnings": {
+    "ok": false,
+    "status": "error"
+  },
+  "missingIndex": {
+    "ok": false,
+    "status": "error"
+  }
+}

--- a/benchmark/fixtures/expected/symbol_metadata.json
+++ b/benchmark/fixtures/expected/symbol_metadata.json
@@ -1,0 +1,141 @@
+{
+  "files": {
+    "python/service.py": {
+      "FixturePythonService": {
+        "analysisMode": "ast",
+        "extractor": "python-ast",
+        "confidenceMin": 0.9
+      },
+      "build_fixture_python": {
+        "analysisMode": "ast",
+        "extractor": "python-ast",
+        "confidenceMin": 0.9
+      }
+    },
+    "typescript/component.ts": {
+      "FixtureTypeScriptComponent": {
+        "analysisMode": "regex",
+        "extractor": "javascript-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "renderFixtureTypeScript": {
+        "analysisMode": "regex",
+        "extractor": "javascript-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "go/service.go": {
+      "FixtureGoService": {
+        "analysisMode": "regex",
+        "extractor": "go-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "NewFixtureGoService": {
+        "analysisMode": "regex",
+        "extractor": "go-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "java/FixtureJavaService.java": {
+      "FixtureJavaService": {
+        "analysisMode": "regex",
+        "extractor": "java-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "runFixtureJava": {
+        "analysisMode": "regex",
+        "extractor": "java-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "kotlin/FixtureKotlinService.kt": {
+      "FixtureKotlinService": {
+        "analysisMode": "regex",
+        "extractor": "kotlin-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "renderFixtureKotlin": {
+        "analysisMode": "regex",
+        "extractor": "kotlin-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "rust/lib.rs": {
+      "FixtureRustService": {
+        "analysisMode": "regex",
+        "extractor": "rust-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "build_fixture_rust": {
+        "analysisMode": "regex",
+        "extractor": "rust-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "php/Service.php": {
+      "FixturePhpService": {
+        "analysisMode": "regex",
+        "extractor": "php-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "buildFixturePhp": {
+        "analysisMode": "regex",
+        "extractor": "php-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "ruby/service.rb": {
+      "FixtureRubyService": {
+        "analysisMode": "regex",
+        "extractor": "ruby-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "run_fixture_ruby": {
+        "analysisMode": "regex",
+        "extractor": "ruby-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    },
+    "csharp/Service.cs": {
+      "FixtureCSharpService": {
+        "analysisMode": "regex",
+        "extractor": "csharp-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      },
+      "RunFixtureCSharp": {
+        "analysisMode": "regex",
+        "extractor": "csharp-regex",
+        "confidenceMin": 0.7,
+        "confidenceMax": 0.89
+      }
+    }
+  },
+  "meta": {
+    "analysisModes": {
+      "csharp": {"regex": 2},
+      "go": {"regex": 2},
+      "java": {"regex": 2},
+      "kotlin": {"regex": 2},
+      "php": {"regex": 2},
+      "python": {"ast": 2},
+      "ruby": {"regex": 2},
+      "rust": {"regex": 2},
+      "typescript": {"regex": 2}
+    }
+  }
+}

--- a/benchmark/fixtures/repo_intelligence/csharp/Service.cs
+++ b/benchmark/fixtures/repo_intelligence/csharp/Service.cs
@@ -1,0 +1,4 @@
+public class FixtureCSharpService
+{
+    public int RunFixtureCSharp(string input) => input.Length;
+}

--- a/benchmark/fixtures/repo_intelligence/go/service.go
+++ b/benchmark/fixtures/repo_intelligence/go/service.go
@@ -1,0 +1,7 @@
+package fixtures
+
+type FixtureGoService struct{}
+
+func NewFixtureGoService() FixtureGoService {
+    return FixtureGoService{}
+}

--- a/benchmark/fixtures/repo_intelligence/java/FixtureJavaService.java
+++ b/benchmark/fixtures/repo_intelligence/java/FixtureJavaService.java
@@ -1,0 +1,5 @@
+public class FixtureJavaService {
+    public String runFixtureJava() {
+        return "java";
+    }
+}

--- a/benchmark/fixtures/repo_intelligence/kotlin/FixtureKotlinService.kt
+++ b/benchmark/fixtures/repo_intelligence/kotlin/FixtureKotlinService.kt
@@ -1,0 +1,5 @@
+class FixtureKotlinService {
+    fun renderFixtureKotlin(): String {
+        return "kotlin"
+    }
+}

--- a/benchmark/fixtures/repo_intelligence/php/Service.php
+++ b/benchmark/fixtures/repo_intelligence/php/Service.php
@@ -1,0 +1,6 @@
+<?php
+class FixturePhpService {}
+
+function buildFixturePhp() {
+    return new FixturePhpService();
+}

--- a/benchmark/fixtures/repo_intelligence/python/service.py
+++ b/benchmark/fixtures/repo_intelligence/python/service.py
@@ -1,0 +1,7 @@
+class FixturePythonService:
+    def run(self):
+        return "python"
+
+
+def build_fixture_python():
+    return FixturePythonService()

--- a/benchmark/fixtures/repo_intelligence/ruby/service.rb
+++ b/benchmark/fixtures/repo_intelligence/ruby/service.rb
@@ -1,0 +1,5 @@
+class FixtureRubyService
+  def run_fixture_ruby
+    "ruby"
+  end
+end

--- a/benchmark/fixtures/repo_intelligence/rust/lib.rs
+++ b/benchmark/fixtures/repo_intelligence/rust/lib.rs
@@ -1,0 +1,5 @@
+pub struct FixtureRustService;
+
+pub fn build_fixture_rust() -> FixtureRustService {
+    FixtureRustService
+}

--- a/benchmark/fixtures/repo_intelligence/typescript/component.ts
+++ b/benchmark/fixtures/repo_intelligence/typescript/component.ts
@@ -1,0 +1,5 @@
+export class FixtureTypeScriptComponent {}
+
+export function renderFixtureTypeScript() {
+  return new FixtureTypeScriptComponent();
+}

--- a/benchmark/test_cli.py
+++ b/benchmark/test_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-CLI integration tests for: lookup, dependencies, high-blast.
+CLI integration tests for: lookup, dependencies, high-blast, doctor, ci.
 
 Usage:
   python benchmark/test_cli.py [--repo PATH] [--codeindex PATH]
@@ -166,12 +166,109 @@ def test_high_blast(exe: str, repo: str, r: Results, index_path: str) -> None:
     r.check("exit non-zero for missing index", rc != 0)
 
 
+def test_doctor(exe: str, repo: str, r: Results, index_path: str, sym_path: str) -> None:
+    print("\n── doctor ──")
+
+    rc, out, err = run([
+        exe, "doctor", repo,
+        "--index", index_path,
+        "--symbol-index", sym_path,
+    ], repo)
+    r.check("exit 0 for healthy indexes", rc == 0, err.strip())
+    r.check("human output contains status", "codeindex doctor:" in out, repr(out[:200]))
+
+    rc, out, err = run([
+        exe, "doctor", repo,
+        "--index", index_path,
+        "--symbol-index", sym_path,
+        "--json",
+    ], repo)
+    r.check("--json exit 0", rc == 0, err.strip())
+    try:
+        data = json.loads(out)
+        r.check("--json ok field", data.get("ok") is True, repr(out[:200]))
+        r.check("--json checks list", isinstance(data.get("checks"), list))
+        r.check("--json summary present", isinstance(data.get("summary"), dict))
+    except json.JSONDecodeError as exc:
+        r.check("--json parses", False, str(exc))
+
+    rc, out, err = run([
+        exe, "doctor", repo,
+        "--index", "/tmp/no_such_codeindex.json",
+        "--symbol-index", sym_path,
+    ], repo)
+    r.check("exit non-zero for missing codeindex", rc != 0)
+
+
+def test_ci(exe: str, repo: str, r: Results, index_path: str, sym_path: str) -> None:
+    print("\n── ci ──")
+
+    rc, out, err = run([
+        exe, "ci", repo,
+        "--base", "HEAD",
+        "--index", index_path,
+        "--symbol-index", sym_path,
+    ], repo)
+    r.check("exit 0 for ci preflight", rc == 0, err.strip())
+    r.check("human output contains status", "codeindex ci:" in out, repr(out[:200]))
+
+    rc, out, err = run([
+        exe, "ci", repo,
+        "--base", "HEAD",
+        "--index", index_path,
+        "--symbol-index", sym_path,
+        "--json",
+    ], repo)
+    r.check("--json exit 0", rc == 0, err.strip())
+    try:
+        data = json.loads(out)
+        r.check("--json status field", data.get("status") in {"ok", "warning", "error"}, repr(out[:200]))
+        r.check("--json changes present", isinstance(data.get("changes"), dict))
+        r.check("--json blast present", isinstance(data.get("blast"), dict))
+        r.check("--json checks list", isinstance(data.get("checks"), list))
+    except json.JSONDecodeError as exc:
+        r.check("--json parses", False, str(exc))
+
+    missing_symbol_index = "/tmp/no_such_symbolindex_codeindex_tests.json"
+    rc, out, err = run([
+        exe, "ci", repo,
+        "--base", "HEAD",
+        "--index", index_path,
+        "--symbol-index", missing_symbol_index,
+        "--json",
+    ], repo)
+    r.check("non-strict warnings exit 0", rc == 0, err.strip())
+    try:
+        data = json.loads(out)
+        r.check("non-strict warnings keep ok=true", data.get("ok") is True, repr(out[:200]))
+        r.check("non-strict warnings status warning", data.get("status") == "warning", repr(out[:200]))
+    except json.JSONDecodeError as exc:
+        r.check("non-strict warning JSON parses", False, str(exc))
+
+    rc, out, err = run([
+        exe, "ci", repo,
+        "--base", "HEAD",
+        "--index", index_path,
+        "--symbol-index", missing_symbol_index,
+        "--strict",
+    ], repo)
+    r.check("strict warnings exit non-zero", rc != 0, repr(out[:200] + err[:200]))
+
+    rc, out, err = run([
+        exe, "ci", repo,
+        "--base", "HEAD",
+        "--index", "/tmp/no_such_codeindex.json",
+        "--symbol-index", sym_path,
+    ], repo)
+    r.check("exit non-zero for missing codeindex", rc != 0)
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 def main() -> None:
     import argparse
-    parser = argparse.ArgumentParser(description="CLI integration tests: lookup, dependencies, high-blast")
+    parser = argparse.ArgumentParser(description="CLI integration tests: lookup, dependencies, high-blast, doctor, ci")
     parser.add_argument("--repo", default=".", help="Repo path (default: .)")
     parser.add_argument("--codeindex", default="codeindex", help="Path to codeindex executable (default: codeindex)")
     args = parser.parse_args()
@@ -218,6 +315,8 @@ def main() -> None:
     test_lookup(exe, repo, r, sym_name, expected_file)
     test_dependencies(exe, repo, r, probe_file, index_path)
     test_high_blast(exe, repo, r, index_path)
+    test_doctor(exe, repo, r, index_path, sym_path)
+    test_ci(exe, repo, r, index_path, sym_path)
 
     r.summary()
     sys.exit(0 if r.failed == 0 else 1)

--- a/benchmark/test_mcp.py
+++ b/benchmark/test_mcp.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 """
-MCP server integration test — exercises all 6 tools via real JSON-RPC stdio.
+MCP server integration test — exercises all MCP tools via real JSON-RPC stdio.
 
 Usage:
   python benchmark/test_mcp.py [--repo PATH] [--codeindex PATH]
 
 Starts the MCP server as a subprocess, sends JSON-RPC messages, validates responses.
-All 6 tools tested: analyze_repo, get_impact, get_dependencies,
-get_high_blast_files, build_symbol_index, lookup_symbol.
 """
 from __future__ import annotations
 
@@ -143,7 +141,8 @@ def test_tools_list(client: MCPClient, r: Results) -> None:
     r.check("no error", "error" not in resp, str(resp.get("error")))
     tools = {t["name"] for t in resp.get("result", {}).get("tools", [])}
     for name in ["analyze_repo", "get_impact", "get_dependencies",
-                 "get_high_blast_files", "build_symbol_index", "lookup_symbol"]:
+                 "get_high_blast_files", "build_symbol_index", "lookup_symbol",
+                 "get_symbol_metadata", "verify_repo_health", "run_ci_check"]:
         r.check(f"tool registered: {name}", name in tools)
 
 
@@ -239,6 +238,54 @@ def test_lookup_symbol(client: MCPClient, r: Results, symbols: list[tuple[str, s
     r.check("unknown symbol returns found=false", data3.get("found") is False, str(data3))
 
 
+def test_get_symbol_metadata(client: MCPClient, r: Results, symbols: list[tuple[str, str, int]]) -> None:
+    print("\n── get_symbol_metadata ──")
+    if not symbols:
+        r.check("probe symbols available", False, "symbolindex.json has no symbols")
+        return
+
+    sym_name = symbols[0][0]
+    resp = client.call_tool("get_symbol_metadata", {"name": sym_name})
+    r.check("no error", not _is_error(resp), _result_text(resp))
+    data = _result_data(resp)
+    r.check("found=true", data.get("found") is True, str(data))
+    r.check("index meta present", isinstance(data.get("indexMeta"), dict), str(data))
+    matches = data.get("matches", [])
+    r.check("matches list present", isinstance(matches, list) and bool(matches), str(data))
+    if matches:
+        first = matches[0]
+        r.check("analysisMode present", "analysisMode" in first, str(first))
+        r.check("extractor present", "extractor" in first, str(first))
+        r.check("confidence present", "confidence" in first, str(first))
+
+    resp2 = client.call_tool("get_symbol_metadata", {"name": "__nonexistent_symbol_xyz__"})
+    data2 = _result_data(resp2)
+    r.check("unknown symbol returns found=false", data2.get("found") is False, str(data2))
+
+
+def test_verify_repo_health(client: MCPClient, r: Results, repo: str) -> None:
+    print("\n── verify_repo_health ──")
+    resp = client.call_tool("verify_repo_health", {"repo_path": repo})
+    r.check("no error", not _is_error(resp), _result_text(resp))
+    data = _result_data(resp)
+    r.check("ok field present", "ok" in data, str(data))
+    r.check("status present", data.get("status") in {"ok", "warning", "error"}, str(data))
+    r.check("summary present", isinstance(data.get("summary"), dict), str(data))
+    r.check("checks list present", isinstance(data.get("checks"), list), str(data))
+
+
+def test_run_ci_check(client: MCPClient, r: Results, repo: str) -> None:
+    print("\n── run_ci_check ──")
+    resp = client.call_tool("run_ci_check", {"repo_path": repo, "base_ref": "HEAD"})
+    r.check("no error", not _is_error(resp), _result_text(resp))
+    data = _result_data(resp)
+    r.check("status present", data.get("status") in {"ok", "warning", "error"}, str(data))
+    r.check("summary present", isinstance(data.get("summary"), dict), str(data))
+    r.check("changes present", isinstance(data.get("changes"), dict), str(data))
+    r.check("blast present", isinstance(data.get("blast"), dict), str(data))
+    r.check("checks list present", isinstance(data.get("checks"), list), str(data))
+
+
 def test_unknown_tool(client: MCPClient, r: Results) -> None:
     print("\n── error handling ──")
     resp = client.call_tool("nonexistent_tool", {})
@@ -307,6 +354,9 @@ def main() -> None:
         test_get_high_blast_files(client, r)
         test_build_symbol_index(client, r, repo)
         test_lookup_symbol(client, r, probe_symbols)
+        test_get_symbol_metadata(client, r, probe_symbols)
+        test_verify_repo_health(client, r, repo)
+        test_run_ci_check(client, r, repo)
         test_unknown_tool(client, r)
     finally:
         client.close()

--- a/benchmark/test_schema_metadata.py
+++ b/benchmark/test_schema_metadata.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from codeindex.ci import run_ci_check
+from codeindex.doctor import inspect_repo
+from codeindex.index import build
+from codeindex.symbol_extractor import extract_csharp
+from codeindex.symbols import build_symbol_index
+
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "repo_intelligence"
+EXPECTED_ROOT = Path(__file__).parent / "fixtures" / "expected"
+
+
+def _load_expected(name: str) -> dict:
+    return json.loads((EXPECTED_ROOT / name).read_text())
+
+
+class SchemaMetadataTests(unittest.TestCase):
+    def assert_symbol_metadata(self, symbol: dict, expected: dict) -> None:
+        self.assertEqual(symbol["analysisMode"], expected["analysisMode"])
+        self.assertEqual(symbol["extractor"], expected["extractor"])
+        self.assertEqual(symbol["schemaVersion"], 1)
+        self.assertIn("extractorVersion", symbol)
+        self.assertIn("confidence", symbol)
+        self.assertGreaterEqual(symbol["confidence"], expected["confidenceMin"])
+        if "confidenceMax" in expected:
+            self.assertLessEqual(symbol["confidence"], expected["confidenceMax"])
+
+    def test_symbol_index_contains_schema_and_confidence_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "service.py").write_text("class Service:\n    pass\n")
+            data = build_symbol_index(str(root))
+
+        self.assertEqual(data["schemaVersion"], 1)
+        meta = data["meta"]
+        self.assertEqual(meta["schemaVersion"], 1)
+        self.assertIn("generatedAt", meta)
+        self.assertIn("toolVersion", meta)
+        self.assertEqual(meta["analysisModes"]["python"]["ast"], 1)
+        self.assertGreaterEqual(meta["confidence"]["average"], 0.9)
+
+        symbol = data["file_symbols"]["service.py"][0]
+        self.assertEqual(symbol["analysisMode"], "ast")
+        self.assertEqual(symbol["extractor"], "python-ast")
+        self.assertIn("confidence", symbol)
+
+    def test_codeindex_contains_additive_schema_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "service.py").write_text("import os\n")
+            output = root / "index.json"
+            data = build(str(root), output)
+            written = json.loads(output.read_text())
+
+        for index_data in (data, written):
+            self.assertEqual(index_data["schemaVersion"], 1)
+            meta = index_data["meta"]
+            self.assertEqual(meta["schemaVersion"], 1)
+            self.assertIn("generatedAt", meta)
+            self.assertIn("toolVersion", meta)
+            self.assertIn("diagnostics", meta)
+            self.assertIn("analysisModes", meta)
+            self.assertTrue(meta["indexed"])
+
+    def test_doctor_reports_healthy_generated_indexes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "service.py").write_text("class Service:\n    pass\n")
+            index_path = root / "codeindex.json"
+            symbol_path = root / "symbolindex.json"
+            build(str(root), index_path)
+            symbol_path.write_text(json.dumps(build_symbol_index(str(root))))
+
+            report = inspect_repo(str(root), max_age_days=7)
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(report["summary"]["errors"], 0)
+        self.assertEqual(report["summary"]["warnings"], 0)
+
+    def test_doctor_reports_missing_codeindex_as_error(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            report = inspect_repo(td)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "error")
+        self.assertGreaterEqual(report["summary"]["errors"], 1)
+
+    def test_fixture_symbol_metadata_matches_expected_truth(self) -> None:
+        expected = _load_expected("symbol_metadata.json")
+        with patch("codeindex.symbol_extractor._extract_csharp_roslyn", return_value=None):
+            data = build_symbol_index(str(FIXTURE_ROOT))
+
+        self.assertEqual(set(data["file_symbols"]), set(expected["files"]))
+        for file_path, expected_symbols in expected["files"].items():
+            by_name = {symbol["name"]: symbol for symbol in data["file_symbols"][file_path]}
+            self.assertEqual(set(by_name), set(expected_symbols), file_path)
+            for name, metadata in expected_symbols.items():
+                self.assert_symbol_metadata(by_name[name], metadata)
+
+        self.assertEqual(
+            data["meta"]["analysisModes"],
+            expected["meta"]["analysisModes"],
+        )
+        self.assertEqual(data["meta"]["confidence"]["bands"]["high"], 2)
+        self.assertEqual(data["meta"]["confidence"]["bands"]["medium"], 16)
+
+    def test_fixture_csharp_roslyn_and_regex_metadata_are_distinguishable(self) -> None:
+        fixture = FIXTURE_ROOT / "csharp" / "Service.cs"
+        with patch("codeindex.symbol_extractor._extract_csharp_roslyn", return_value=[{
+            "name": "FixtureCSharpService",
+            "line": 1,
+            "kind": "class",
+            "exported": True,
+        }]):
+            roslyn_symbols = extract_csharp(fixture)
+        with patch("codeindex.symbol_extractor._extract_csharp_roslyn", return_value=None):
+            regex_symbols = extract_csharp(fixture)
+
+        roslyn = roslyn_symbols[0]
+        regex = {symbol["name"]: symbol for symbol in regex_symbols}["FixtureCSharpService"]
+        self.assertEqual(roslyn["analysisMode"], "roslyn")
+        self.assertEqual(roslyn["extractor"], "codeindex-csharp-symbols")
+        self.assertEqual(regex["analysisMode"], "regex")
+        self.assertEqual(regex["extractor"], "csharp-regex")
+        self.assertGreater(roslyn["confidence"], regex["confidence"])
+
+    def test_legacy_indexes_warn_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            codeindex_path = root / "legacy-codeindex.json"
+            symbol_path = root / "legacy-symbolindex.json"
+            codeindex_path.write_text(json.dumps({
+                "meta": {"languages": ["python"], "diagnostics": []},
+                "nodes": [],
+                "links": [],
+            }))
+            symbol_path.write_text(json.dumps({
+                "meta": {"generated": "2026-05-30", "repo": "legacy/", "total_symbols": 0, "diagnostics": []},
+                "symbols": {},
+                "file_symbols": {},
+            }))
+
+            report = inspect_repo(
+                str(root),
+                index_path=str(codeindex_path),
+                symbol_index_path=str(symbol_path),
+            )
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["status"], "warning")
+        self.assertEqual(report["summary"]["errors"], 0)
+        warning_names = {check["name"] for check in report["checks"] if check["status"] == "warning"}
+        self.assertIn("codeindex-schema", warning_names)
+        self.assertIn("codeindex-freshness", warning_names)
+        self.assertIn("symbolindex-schema", warning_names)
+        self.assertIn("symbolindex-freshness", warning_names)
+
+    def test_ci_warning_policy_matches_expected_truth(self) -> None:
+        expected = _load_expected("ci_policy.json")
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            index_path = root / "codeindex.json"
+            symbol_path = root / "symbolindex.json"
+            index_path.write_text(json.dumps({
+                "meta": {"languages": ["python"], "diagnostics": []},
+                "nodes": [],
+                "links": [],
+            }))
+            symbol_path.write_text(json.dumps({
+                "meta": {"generated": "2026-05-30", "repo": "legacy/", "total_symbols": 0, "diagnostics": []},
+                "symbols": {},
+                "file_symbols": {},
+            }))
+
+            non_strict = run_ci_check(str(root), index_path=str(index_path), symbol_index_path=str(symbol_path))
+            strict = run_ci_check(str(root), index_path=str(index_path), symbol_index_path=str(symbol_path), strict=True)
+            missing = run_ci_check(str(root), index_path=str(root / "missing-codeindex.json"), symbol_index_path=str(symbol_path))
+
+        self.assertEqual(non_strict["ok"], expected["nonStrictWarnings"]["ok"])
+        self.assertEqual(non_strict["status"], expected["nonStrictWarnings"]["status"])
+        self.assertEqual(strict["ok"], expected["strictWarnings"]["ok"])
+        self.assertEqual(strict["status"], expected["strictWarnings"]["status"])
+        self.assertEqual(missing["ok"], expected["missingIndex"]["ok"])
+        self.assertEqual(missing["status"], expected["missingIndex"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/test_symbol_extractor.py
+++ b/benchmark/test_symbol_extractor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from codeindex.symbol_extractor import extract_csharp, extract_symbols
+
+
+class CSharpSymbolExtractorTests(unittest.TestCase):
+    def test_csharp_regex_fallback_extracts_types_and_methods(self) -> None:
+        src = """
+public class PublicService
+{
+    public int Run(string input) => 1;
+    private void Hidden() { }
+}
+
+internal class InternalOnly {}
+"""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "service.cs"
+            path.write_text(src)
+            symbols = extract_symbols(path)
+
+        by_name = {s["name"]: s for s in symbols}
+        self.assertEqual(by_name["PublicService"]["kind"], "class")
+        self.assertTrue(by_name["PublicService"]["exported"])
+        self.assertEqual(by_name["Run"]["kind"], "function")
+        self.assertTrue(by_name["Run"]["exported"])
+        self.assertFalse(by_name["InternalOnly"]["exported"])
+
+    def test_csharp_prefers_roslyn_output_when_available(self) -> None:
+        roslyn = [{"name": "FromRoslyn", "line": 7, "kind": "class", "exported": True}]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "service.cs"
+            path.write_text("public class A {}")
+            with patch("codeindex.symbol_extractor._extract_csharp_roslyn", return_value=roslyn):
+                symbols = extract_csharp(path)
+        self.assertEqual(symbols, roslyn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/test_symbol_extractor.py
+++ b/benchmark/test_symbol_extractor.py
@@ -10,6 +10,13 @@ from codeindex.symbol_extractor import extract_csharp, extract_symbols
 
 
 class CSharpSymbolExtractorTests(unittest.TestCase):
+    def assert_metadata(self, symbol: dict, mode: str, extractor: str) -> None:
+        self.assertEqual(symbol["analysisMode"], mode)
+        self.assertEqual(symbol["extractor"], extractor)
+        self.assertIn("extractorVersion", symbol)
+        self.assertIn("confidence", symbol)
+        self.assertIn("schemaVersion", symbol)
+
     def test_csharp_regex_fallback_extracts_types_and_methods(self) -> None:
         src = """
 public class PublicService
@@ -31,6 +38,7 @@ internal class InternalOnly {}
         self.assertEqual(by_name["Run"]["kind"], "function")
         self.assertTrue(by_name["Run"]["exported"])
         self.assertFalse(by_name["InternalOnly"]["exported"])
+        self.assert_metadata(by_name["PublicService"], "regex", "csharp-regex")
 
     def test_csharp_prefers_roslyn_output_when_available(self) -> None:
         roslyn = [{"name": "FromRoslyn", "line": 7, "kind": "class", "exported": True}]
@@ -39,7 +47,27 @@ internal class InternalOnly {}
             path.write_text("public class A {}")
             with patch("codeindex.symbol_extractor._extract_csharp_roslyn", return_value=roslyn):
                 symbols = extract_csharp(path)
-        self.assertEqual(symbols, roslyn)
+        self.assertEqual(symbols[0]["name"], "FromRoslyn")
+        self.assert_metadata(symbols[0], "roslyn", "codeindex-csharp-symbols")
+        self.assertGreater(symbols[0]["confidence"], 0.9)
+
+    def test_python_ast_symbols_include_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "service.py"
+            path.write_text("class Service:\n    def run(self):\n        pass\n")
+            symbols = extract_symbols(path)
+        by_name = {s["name"]: s for s in symbols}
+        self.assert_metadata(by_name["Service"], "ast", "python-ast")
+        self.assertGreater(by_name["Service"]["confidence"], 0.9)
+
+    def test_javascript_regex_symbols_include_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "component.ts"
+            path.write_text("export class Widget {}\nexport function render() {}\n")
+            symbols = extract_symbols(path)
+        by_name = {s["name"]: s for s in symbols}
+        self.assert_metadata(by_name["Widget"], "regex", "javascript-regex")
+        self.assertLess(by_name["Widget"]["confidence"], 0.9)
 
 
 if __name__ == "__main__":

--- a/codeindex/__init__.py
+++ b/codeindex/__init__.py
@@ -1,2 +1,2 @@
 """codeindex — repo dependency analyzer with blast-radius impact scoring."""
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/codeindex/ci.py
+++ b/codeindex/ci.py
@@ -1,0 +1,177 @@
+"""CI and PR preflight checks for codeindex artifacts and changed files."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from codeindex.doctor import inspect_repo
+from codeindex.index import INDEX_FILENAME, load
+from codeindex.symbols import SYMBOL_INDEX_FILENAME
+
+
+def _add_check(checks: list[dict], name: str, status: str, message: str) -> None:
+    checks.append({"name": name, "status": status, "message": message})
+
+
+def _git_lines(repo: Path, args: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise RuntimeError(detail)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _changed_files(repo: Path, base_ref: str | None, include_untracked: bool) -> tuple[list[str], str | None]:
+    changed: set[str] = set()
+    try:
+        if base_ref:
+            changed.update(_git_lines(repo, ["diff", "--name-only", "--diff-filter=AM", f"{base_ref}...HEAD"]))
+        else:
+            changed.update(_git_lines(repo, ["diff", "--name-only", "--diff-filter=AM"]))
+            changed.update(_git_lines(repo, ["diff", "--cached", "--name-only", "--diff-filter=AM"]))
+        if include_untracked:
+            changed.update(_git_lines(repo, ["ls-files", "--others", "--exclude-standard"]))
+    except RuntimeError as exc:
+        return [], str(exc)
+    return sorted(changed), None
+
+
+def _find_node(file_path: str, nodes: list[dict]) -> dict | None:
+    clean = file_path.lstrip("./")
+    for node in nodes:
+        node_id = node.get("id", "")
+        if node_id == file_path or node_id == clean or node_id.endswith(clean) or clean.endswith(node_id):
+            return node
+    return None
+
+
+def _blast_findings(index_path: Path, changed_files: list[str], threshold: float) -> tuple[list[dict], str | None]:
+    try:
+        data = load(index_path)
+    except Exception as exc:
+        return [], str(exc)
+
+    nodes = data.get("nodes", [])
+    findings: list[dict] = []
+    for changed_file in changed_files:
+        node = _find_node(changed_file, nodes)
+        if not node or node.get("type") == "import":
+            continue
+        blast_score = float(node.get("blast_score", 0))
+        if blast_score >= threshold:
+            findings.append({
+                "file": node.get("id", changed_file),
+                "blast_score": blast_score,
+                "direct": node.get("direct_dependents", 0),
+                "transitive": node.get("transitive_dependents", 0),
+            })
+
+    findings.sort(key=lambda item: item["blast_score"], reverse=True)
+    return findings, None
+
+
+def run_ci_check(
+    repo_path: str,
+    *,
+    base_ref: str | None = None,
+    index_path: str | None = None,
+    symbol_index_path: str | None = None,
+    max_age_days: int = 7,
+    blast_threshold: float = 10.0,
+    strict: bool = False,
+    include_untracked: bool = False,
+) -> dict:
+    """Run a CI-friendly codeindex preflight check."""
+    repo = Path(repo_path).resolve()
+    resolved_index = Path(index_path).resolve() if index_path else repo / INDEX_FILENAME
+    resolved_symbol_index = Path(symbol_index_path).resolve() if symbol_index_path else repo / SYMBOL_INDEX_FILENAME
+    checks: list[dict] = []
+
+    doctor = inspect_repo(
+        str(repo),
+        index_path=str(resolved_index),
+        symbol_index_path=str(resolved_symbol_index),
+        max_age_days=max_age_days,
+    )
+    for check in doctor.get("checks", []):
+        _add_check(checks, check.get("name", "doctor"), check.get("status", "warning"), check.get("message", ""))
+
+    changed_files, git_error = _changed_files(repo, base_ref, include_untracked)
+    if git_error:
+        _add_check(checks, "changed-files", "warning", f"could not determine changed files: {git_error}")
+    else:
+        mode = f"base {base_ref}" if base_ref else "working tree and staged changes"
+        _add_check(checks, "changed-files", "ok", f"{len(changed_files)} changed files from {mode}")
+
+    high_blast_files, blast_error = _blast_findings(resolved_index, changed_files, blast_threshold)
+    if blast_error:
+        _add_check(checks, "changed-file-blast", "warning", f"could not evaluate changed-file blast: {blast_error}")
+    elif high_blast_files:
+        _add_check(checks, "changed-file-blast", "warning", f"{len(high_blast_files)} changed files meet blast threshold {blast_threshold:g}")
+    else:
+        _add_check(checks, "changed-file-blast", "ok", f"no changed files meet blast threshold {blast_threshold:g}")
+
+    warning_count = sum(1 for check in checks if check.get("status") == "warning")
+    error_count = sum(1 for check in checks if check.get("status") == "error")
+    fails_strict = strict and warning_count > 0
+    status = "error" if error_count or fails_strict else "warning" if warning_count else "ok"
+
+    return {
+        "ok": status != "error",
+        "status": status,
+        "strict": strict,
+        "repo": str(repo),
+        "summary": {
+            "errors": error_count,
+            "warnings": warning_count,
+            "checks": len(checks),
+            "changedFiles": len(changed_files),
+            "highBlastFiles": len(high_blast_files),
+        },
+        "doctor": doctor,
+        "changes": {
+            "baseRef": base_ref,
+            "includeUntracked": include_untracked,
+            "files": changed_files,
+        },
+        "blast": {
+            "threshold": blast_threshold,
+            "highRiskFiles": high_blast_files,
+        },
+        "checks": checks,
+    }
+
+
+def format_ci_report(report: dict) -> str:
+    """Format a human-readable CI preflight report."""
+    summary = report.get("summary", {})
+    lines = [
+        f"codeindex ci: {report.get('status', 'unknown').upper()}",
+        f"repo: {report.get('repo')}",
+        f"checks: {summary.get('checks', 0)}  errors: {summary.get('errors', 0)}  warnings: {summary.get('warnings', 0)}",
+        f"changed files: {summary.get('changedFiles', 0)}  high-blast changed files: {summary.get('highBlastFiles', 0)}",
+        "",
+    ]
+
+    for check in report.get("checks", []):
+        marker = "OK" if check.get("status") == "ok" else check.get("status", "warning").upper()
+        lines.append(f"[{marker}] {check.get('name')}: {check.get('message')}")
+
+    high_risk = report.get("blast", {}).get("highRiskFiles", [])
+    if high_risk:
+        lines.extend(["", "High-blast changed files:"])
+        for item in high_risk:
+            lines.append(
+                f"  {item['blast_score']:>6.1f}  {item['file']}"
+                f"  ({item.get('direct', 0)}d / {item.get('transitive', 0)}t)"
+            )
+
+    if report.get("strict") and summary.get("warnings", 0):
+        lines.extend(["", "Strict mode treats warnings as failures."])
+
+    return "\n".join(lines)

--- a/codeindex/cli.py
+++ b/codeindex/cli.py
@@ -261,6 +261,44 @@ def _cmd_install_hook(args: argparse.Namespace) -> None:
     )
 
 
+def _cmd_doctor(args: argparse.Namespace) -> None:
+    from codeindex.doctor import format_doctor_report, inspect_repo
+
+    report = inspect_repo(
+        args.repo,
+        index_path=args.index,
+        symbol_index_path=args.symbol_index,
+        max_age_days=args.max_age_days,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_doctor_report(report))
+    if report["summary"]["errors"]:
+        sys.exit(1)
+
+
+def _cmd_ci(args: argparse.Namespace) -> None:
+    from codeindex.ci import format_ci_report, run_ci_check
+
+    report = run_ci_check(
+        args.repo,
+        base_ref=args.base,
+        index_path=args.index,
+        symbol_index_path=args.symbol_index,
+        max_age_days=args.max_age_days,
+        blast_threshold=args.blast_threshold,
+        strict=args.strict,
+        include_untracked=args.include_untracked,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_ci_report(report))
+    if report["status"] == "error":
+        sys.exit(1)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="codeindex",
@@ -343,6 +381,26 @@ def _build_parser() -> argparse.ArgumentParser:
     p_hook.add_argument("--strict", action="store_true", help="Block commit when threshold exceeded")
     p_hook.add_argument("--remove", action="store_true", help="Remove the installed hook")
 
+    # ── doctor ─────────────────────────────────────────────────────────────
+    p_doctor = sub.add_parser("doctor", help="Check index health, metadata, freshness, and diagnostics")
+    p_doctor.add_argument("repo", nargs="?", default=".", help="Repo root (default: .)")
+    p_doctor.add_argument("--index", help="Path to codeindex.json (default: <repo>/codeindex.json)")
+    p_doctor.add_argument("--symbol-index", dest="symbol_index", help="Path to symbolindex.json (default: <repo>/symbolindex.json)")
+    p_doctor.add_argument("--max-age-days", type=int, default=7, help="Warn when indexes are older than this many days")
+    p_doctor.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    # ── ci ─────────────────────────────────────────────────────────────────
+    p_ci = sub.add_parser("ci", help="Run CI/PR preflight checks for index health and changed-file blast risk")
+    p_ci.add_argument("repo", nargs="?", default=".", help="Repo root (default: .)")
+    p_ci.add_argument("--base", help="Git base ref for PR diffs, such as origin/main or HEAD")
+    p_ci.add_argument("--index", help="Path to codeindex.json (default: <repo>/codeindex.json)")
+    p_ci.add_argument("--symbol-index", dest="symbol_index", help="Path to symbolindex.json (default: <repo>/symbolindex.json)")
+    p_ci.add_argument("--max-age-days", type=int, default=7, help="Warn when indexes are older than this many days")
+    p_ci.add_argument("--blast-threshold", type=float, default=10.0, help="Warn when changed files meet this blast score (default: 10)")
+    p_ci.add_argument("--include-untracked", action="store_true", help="Include untracked files in local changed-file checks")
+    p_ci.add_argument("--strict", action="store_true", help="Exit non-zero when warnings are present")
+    p_ci.add_argument("--json", action="store_true", help="Output raw JSON")
+
     return parser
 
 
@@ -359,6 +417,8 @@ def main() -> None:
         "dependencies": _cmd_dependencies,
         "high-blast":   _cmd_high_blast,
         "install-hook": _cmd_install_hook,
+        "doctor":       _cmd_doctor,
+        "ci":           _cmd_ci,
     }
     dispatch[args.command](args)
 

--- a/codeindex/doctor.py
+++ b/codeindex/doctor.py
@@ -1,0 +1,151 @@
+"""Repository health checks for generated codeindex artifacts."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from codeindex.index import INDEX_FILENAME
+from codeindex.symbols import SYMBOL_INDEX_FILENAME
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_json(path: Path) -> tuple[dict | None, str | None]:
+    try:
+        return json.loads(path.read_text()), None
+    except OSError as exc:
+        return None, str(exc)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc}"
+
+
+def _check_staleness(generated_at: str | None, max_age_days: int) -> tuple[str, str]:
+    generated = _parse_utc(generated_at)
+    if generated is None:
+        return "warning", "generatedAt metadata is missing or invalid"
+    age_days = (_utc_now() - generated).total_seconds() / 86400
+    if age_days > max_age_days:
+        return "warning", f"index is stale ({age_days:.1f} days old; max {max_age_days})"
+    return "ok", f"index is fresh ({age_days:.1f} days old)"
+
+
+def _add_check(checks: list[dict], name: str, status: str, message: str, path: Path | None = None) -> None:
+    check = {"name": name, "status": status, "message": message}
+    if path is not None:
+        check["path"] = str(path)
+    checks.append(check)
+
+
+def inspect_repo(
+    repo_path: str,
+    index_path: str | None = None,
+    symbol_index_path: str | None = None,
+    max_age_days: int = 7,
+) -> dict:
+    """Return health checks for codeindex.json and symbolindex.json."""
+    root = Path(repo_path).resolve()
+    codeindex_path = Path(index_path).resolve() if index_path else root / INDEX_FILENAME
+    symbol_path = Path(symbol_index_path).resolve() if symbol_index_path else root / SYMBOL_INDEX_FILENAME
+    checks: list[dict] = []
+
+    code_summary = {"path": str(codeindex_path), "exists": codeindex_path.exists()}
+    symbol_summary = {"path": str(symbol_path), "exists": symbol_path.exists()}
+
+    if codeindex_path.exists():
+        data, error = _load_json(codeindex_path)
+        if error:
+            _add_check(checks, "codeindex-json", "error", error, codeindex_path)
+        else:
+            meta = data.get("meta", {}) if isinstance(data, dict) else {}
+            code_summary.update({
+                "schemaVersion": data.get("schemaVersion") if isinstance(data, dict) else None,
+                "generatedAt": meta.get("generatedAt"),
+                "toolVersion": meta.get("toolVersion"),
+                "languages": meta.get("languages", []),
+            })
+            if data.get("schemaVersion") is None:
+                _add_check(checks, "codeindex-schema", "warning", "schemaVersion is missing; index may be legacy", codeindex_path)
+            else:
+                _add_check(checks, "codeindex-schema", "ok", f"schemaVersion={data.get('schemaVersion')}", codeindex_path)
+            status, message = _check_staleness(meta.get("generatedAt"), max_age_days)
+            _add_check(checks, "codeindex-freshness", status, message, codeindex_path)
+            diagnostics = meta.get("diagnostics", [])
+            if diagnostics:
+                _add_check(checks, "codeindex-diagnostics", "warning", f"{len(diagnostics)} diagnostics present", codeindex_path)
+            else:
+                _add_check(checks, "codeindex-diagnostics", "ok", "no diagnostics reported", codeindex_path)
+    else:
+        _add_check(checks, "codeindex-present", "error", f"{INDEX_FILENAME} not found", codeindex_path)
+
+    if symbol_path.exists():
+        data, error = _load_json(symbol_path)
+        if error:
+            _add_check(checks, "symbolindex-json", "error", error, symbol_path)
+        else:
+            meta = data.get("meta", {}) if isinstance(data, dict) else {}
+            symbol_summary.update({
+                "schemaVersion": data.get("schemaVersion") if isinstance(data, dict) else None,
+                "generatedAt": meta.get("generatedAt"),
+                "toolVersion": meta.get("toolVersion"),
+                "totalSymbols": meta.get("total_symbols"),
+                "confidence": meta.get("confidence"),
+                "analysisModes": meta.get("analysisModes", {}),
+            })
+            if data.get("schemaVersion") is None:
+                _add_check(checks, "symbolindex-schema", "warning", "schemaVersion is missing; index may be legacy", symbol_path)
+            else:
+                _add_check(checks, "symbolindex-schema", "ok", f"schemaVersion={data.get('schemaVersion')}", symbol_path)
+            status, message = _check_staleness(meta.get("generatedAt"), max_age_days)
+            _add_check(checks, "symbolindex-freshness", status, message, symbol_path)
+            diagnostics = meta.get("diagnostics", [])
+            if diagnostics:
+                _add_check(checks, "symbolindex-diagnostics", "warning", f"{len(diagnostics)} diagnostics present", symbol_path)
+            else:
+                _add_check(checks, "symbolindex-diagnostics", "ok", "no diagnostics reported", symbol_path)
+    else:
+        _add_check(checks, "symbolindex-present", "warning", f"{SYMBOL_INDEX_FILENAME} not found", symbol_path)
+
+    errors = sum(1 for check in checks if check["status"] == "error")
+    warnings = sum(1 for check in checks if check["status"] == "warning")
+    status = "error" if errors else "warning" if warnings else "ok"
+
+    return {
+        "ok": errors == 0,
+        "status": status,
+        "repo": str(root),
+        "summary": {"errors": errors, "warnings": warnings, "checks": len(checks)},
+        "codeindex": code_summary,
+        "symbolindex": symbol_summary,
+        "checks": checks,
+    }
+
+
+def format_doctor_report(report: dict) -> str:
+    """Format a human-readable doctor report."""
+    lines = [
+        f"codeindex doctor: {report['status'].upper()}",
+        f"Repo: {report['repo']}",
+        f"Checks: {report['summary']['checks']}  errors: {report['summary']['errors']}  warnings: {report['summary']['warnings']}",
+        "",
+    ]
+    for check in report["checks"]:
+        marker = {"ok": "OK", "warning": "WARN", "error": "ERROR"}.get(check["status"], check["status"].upper())
+        path = f" ({check['path']})" if check.get("path") else ""
+        lines.append(f"[{marker}] {check['name']}: {check['message']}{path}")
+    return "\n".join(lines)

--- a/codeindex/index.py
+++ b/codeindex/index.py
@@ -2,12 +2,19 @@
 from __future__ import annotations
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
+from codeindex import __version__
 from codeindex.analyze import analyze
 from codeindex.impact import compute_blast_radius, enrich_nodes, enrich_links
 
 INDEX_FILENAME = "codeindex.json"
+INDEX_SCHEMA_VERSION = 1
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def build(repo_path: str, output: Path | None = None) -> dict:
@@ -19,6 +26,12 @@ def build(repo_path: str, output: Path | None = None) -> dict:
     enrich_links(data["nodes"], data["links"])
 
     # Store blast map in meta for quick lookup
+    data["schemaVersion"] = INDEX_SCHEMA_VERSION
+    data["meta"].setdefault("diagnostics", [])
+    data["meta"].setdefault("analysisModes", {})
+    data["meta"]["schemaVersion"] = INDEX_SCHEMA_VERSION
+    data["meta"]["generatedAt"] = _utc_now()
+    data["meta"]["toolVersion"] = __version__
     data["meta"]["indexed"] = True
 
     dest = output or (root / INDEX_FILENAME)

--- a/codeindex/mcp_server.py
+++ b/codeindex/mcp_server.py
@@ -4,6 +4,7 @@ import json
 import sys
 from pathlib import Path
 
+from codeindex import __version__
 from codeindex.index import build, load, find_index, INDEX_FILENAME
 from codeindex.impact import compute_blast_radius
 from codeindex.reporter import format_markdown
@@ -85,7 +86,7 @@ TOOLS = [
         "name": "lookup_symbol",
         "description": (
             "Find where a function, class, struct, or other symbol is defined. "
-            "Returns file path and line number via O(1) index lookup — no file scanning. "
+            "Returns file path, line number, and any available provenance metadata via O(1) index lookup — no file scanning. "
             "Requires symbolindex.json (run build_symbol_index first)."
         ),
         "inputSchema": {
@@ -101,6 +102,99 @@ TOOLS = [
                 },
             },
             "required": ["name"],
+        },
+    },
+    {
+        "name": "get_symbol_metadata",
+        "description": (
+            "Return provenance metadata for a symbol, including extraction mode, extractor, "
+            "confidence, and symbol index schema metadata when available."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact symbol name to inspect.",
+                },
+                "symbol_index_path": {
+                    "type": "string",
+                    "description": "Path to symbolindex.json. Auto-discovered if omitted.",
+                },
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "verify_repo_health",
+        "description": (
+            "Check codeindex.json and symbolindex.json health, including schema metadata, "
+            "freshness, diagnostics, and missing artifacts."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the repo root. Default: current working directory.",
+                },
+                "index_path": {
+                    "type": "string",
+                    "description": "Path to codeindex.json. Default: <repo>/codeindex.json.",
+                },
+                "symbol_index_path": {
+                    "type": "string",
+                    "description": "Path to symbolindex.json. Default: <repo>/symbolindex.json.",
+                },
+                "max_age_days": {
+                    "type": "number",
+                    "description": "Warn when indexes are older than this many days. Default: 7.",
+                },
+            },
+        },
+    },
+    {
+        "name": "run_ci_check",
+        "description": (
+            "Run a CI/PR preflight check that combines index health, freshness, diagnostics, "
+            "and changed-file blast-radius warnings."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the repo root. Default: current working directory.",
+                },
+                "base_ref": {
+                    "type": "string",
+                    "description": "Git base ref for PR diffs, such as origin/main or HEAD.",
+                },
+                "index_path": {
+                    "type": "string",
+                    "description": "Path to codeindex.json. Default: <repo>/codeindex.json.",
+                },
+                "symbol_index_path": {
+                    "type": "string",
+                    "description": "Path to symbolindex.json. Default: <repo>/symbolindex.json.",
+                },
+                "max_age_days": {
+                    "type": "number",
+                    "description": "Warn when indexes are older than this many days. Default: 7.",
+                },
+                "blast_threshold": {
+                    "type": "number",
+                    "description": "Warn when changed files meet this blast score. Default: 10.",
+                },
+                "strict": {
+                    "type": "boolean",
+                    "description": "Treat warnings as failures.",
+                },
+                "include_untracked": {
+                    "type": "boolean",
+                    "description": "Include untracked files in local changed-file checks.",
+                },
+            },
         },
     },
     {
@@ -246,6 +340,42 @@ def _call_lookup_symbol(params: dict) -> dict:
                 "kind":     m.get("kind", "?"),
                 "exported": m.get("exported", True),
                 "methods":  m.get("methods", []),
+                "analysisMode": m.get("analysisMode"),
+                "extractor": m.get("extractor"),
+                "extractorVersion": m.get("extractorVersion"),
+                "confidence": m.get("confidence"),
+            }
+            for m in matches
+        ],
+    }
+
+
+def _call_get_symbol_metadata(params: dict) -> dict:
+    sym_data = _resolve_symbol_index(params.get("symbol_index_path"))
+    name = params["name"]
+    matches = sym_data.get("symbols", {}).get(name, [])
+    if not matches:
+        return {
+            "found": False,
+            "name": name,
+            "matches": [],
+            "indexMeta": sym_data.get("meta", {}),
+        }
+    return {
+        "found": True,
+        "name": name,
+        "indexMeta": sym_data.get("meta", {}),
+        "matches": [
+            {
+                "file": m.get("file"),
+                "line": m.get("line"),
+                "kind": m.get("kind", "?"),
+                "analysisMode": m.get("analysisMode"),
+                "extractor": m.get("extractor"),
+                "extractorVersion": m.get("extractorVersion"),
+                "confidence": m.get("confidence"),
+                "schemaVersion": m.get("schemaVersion"),
+                "diagnostics": m.get("diagnostics", []),
             }
             for m in matches
         ],
@@ -263,7 +393,37 @@ def _call_build_symbol_index(params: dict) -> dict:
         "total_symbols": symbol_data["meta"]["total_symbols"],
         "files":         len(symbol_data["file_symbols"]),
         "output":        str(out),
+        "schemaVersion": symbol_data.get("schemaVersion"),
+        "analysisModes": symbol_data["meta"].get("analysisModes", {}),
+        "confidence":    symbol_data["meta"].get("confidence", {}),
+        "diagnostics":   symbol_data["meta"].get("diagnostics", []),
     }
+
+
+def _call_verify_repo_health(params: dict) -> dict:
+    from codeindex.doctor import inspect_repo  # noqa: PLC0415
+
+    return inspect_repo(
+        params.get("repo_path", "."),
+        index_path=params.get("index_path"),
+        symbol_index_path=params.get("symbol_index_path"),
+        max_age_days=int(params.get("max_age_days", 7)),
+    )
+
+
+def _call_run_ci_check(params: dict) -> dict:
+    from codeindex.ci import run_ci_check  # noqa: PLC0415
+
+    return run_ci_check(
+        params.get("repo_path", "."),
+        base_ref=params.get("base_ref"),
+        index_path=params.get("index_path"),
+        symbol_index_path=params.get("symbol_index_path"),
+        max_age_days=int(params.get("max_age_days", 7)),
+        blast_threshold=float(params.get("blast_threshold", 10)),
+        strict=bool(params.get("strict", False)),
+        include_untracked=bool(params.get("include_untracked", False)),
+    )
 
 
 _HANDLERS = {
@@ -272,6 +432,9 @@ _HANDLERS = {
     "get_dependencies":    _call_get_dependencies,
     "get_high_blast_files": _call_get_high_blast_files,
     "lookup_symbol":       _call_lookup_symbol,
+    "get_symbol_metadata": _call_get_symbol_metadata,
+    "verify_repo_health":  _call_verify_repo_health,
+    "run_ci_check":        _call_run_ci_check,
     "build_symbol_index":  _call_build_symbol_index,
 }
 
@@ -296,7 +459,7 @@ def _handle(msg: dict) -> dict | None:
         return ok({
             "protocolVersion": "2024-11-05",
             "capabilities": {"tools": {}},
-            "serverInfo": {"name": "codeindex", "version": "0.1.0"},
+            "serverInfo": {"name": "codeindex", "version": __version__},
         })
 
     if method == "notifications/initialized":

--- a/codeindex/symbol_extractor.py
+++ b/codeindex/symbol_extractor.py
@@ -1,7 +1,10 @@
 """Per-language symbol extraction for the codeindex symbol index."""
 from __future__ import annotations
 import ast
+import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 
@@ -317,6 +320,112 @@ def extract_ruby(path: Path) -> list[dict]:
     return symbols
 
 
+# ── C# (Roslyn-first with regex fallback) ────────────────────────────────────
+
+_CSHARP_TYPE = re.compile(
+    r"^\s*(?:\[[^\]]+\]\s*)*"
+    r"(?P<mods>(?:(?:public|private|protected|internal|static|abstract|sealed|partial|readonly|unsafe|new)\s+)*)"
+    r"(?P<kind>class|interface|struct|enum|delegate|record(?:\s+class|\s+struct)?)\s+"
+    r"(?P<name>@?\w+)",
+    re.MULTILINE,
+)
+_CSHARP_METHOD = re.compile(
+    r"^\s*(?:\[[^\]]+\]\s*)*"
+    r"(?P<mods>(?:(?:public|private|protected|internal|static|virtual|override|abstract|sealed|async|extern|unsafe|new|partial)\s+)+)"
+    r"(?:[\w<>\[\],\.\?]+\s+)+(?P<name>@?\w+)\s*\(",
+    re.MULTILINE,
+)
+_CSHARP_NOISE = {"if", "for", "while", "switch", "foreach", "catch", "lock", "using", "return"}
+
+
+def _extract_csharp_roslyn(path: Path) -> list[dict] | None:
+    tool = shutil.which("codeindex-csharp-symbols")
+    if not tool:
+        return None
+    try:
+        result = subprocess.run(
+            [tool, str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, list):
+        return None
+    symbols: list[dict] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        line = item.get("line")
+        kind = item.get("kind", "class")
+        if not isinstance(name, str) or not isinstance(line, int):
+            continue
+        symbol = {
+            "name": name,
+            "line": line,
+            "kind": str(kind),
+            "exported": bool(item.get("exported", True)),
+        }
+        if isinstance(item.get("methods"), list):
+            symbol["methods"] = [m for m in item["methods"] if isinstance(m, str)]
+        if isinstance(item.get("doc"), str) and item["doc"]:
+            symbol["doc"] = item["doc"][:80]
+        symbols.append(symbol)
+    return symbols
+
+
+def extract_csharp(path: Path) -> list[dict]:
+    roslyn_symbols = _extract_csharp_roslyn(path)
+    if roslyn_symbols is not None:
+        return roslyn_symbols
+    try:
+        source = path.read_text(errors="replace")
+    except OSError:
+        return []
+
+    symbols = []
+    seen: set[str] = set()
+
+    for m in _CSHARP_TYPE.finditer(source):
+        name = m.group("name")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        mods = m.group("mods") or ""
+        raw_kind = m.group("kind") or "class"
+        kind = "class" if raw_kind.startswith("record") else raw_kind
+        symbols.append({
+            "name": name,
+            "line": _line_of(source, m.start()),
+            "kind": kind,
+            "exported": "public" in mods.split(),
+        })
+
+    for m in _CSHARP_METHOD.finditer(source):
+        name = m.group("name")
+        if not name or name in seen or name in _CSHARP_NOISE:
+            continue
+        seen.add(name)
+        mods = m.group("mods") or ""
+        symbols.append({
+            "name": name,
+            "line": _line_of(source, m.start()),
+            "kind": "function",
+            "exported": "public" in mods.split(),
+        })
+
+    return symbols
+
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 
 EXTRACTORS: dict[str, callable] = {
@@ -335,6 +444,7 @@ EXTRACTORS: dict[str, callable] = {
     ".rs":   extract_rust,
     ".php":  extract_php,
     ".rb":   extract_ruby,
+    ".cs":   extract_csharp,
 }
 
 

--- a/codeindex/symbol_extractor.py
+++ b/codeindex/symbol_extractor.py
@@ -6,6 +6,31 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Callable
+
+SYMBOL_SCHEMA_VERSION = 1
+EXTRACTOR_VERSION = "1"
+
+
+def _with_symbol_metadata(
+    symbols: list[dict],
+    analysis_mode: str,
+    extractor: str,
+    confidence: float,
+    diagnostics: list[str] | None = None,
+) -> list[dict]:
+    enriched = []
+    for symbol in symbols:
+        item = dict(symbol)
+        item.setdefault("analysisMode", analysis_mode)
+        item.setdefault("extractor", extractor)
+        item.setdefault("extractorVersion", EXTRACTOR_VERSION)
+        item.setdefault("confidence", confidence)
+        item.setdefault("schemaVersion", SYMBOL_SCHEMA_VERSION)
+        if diagnostics:
+            item.setdefault("diagnostics", diagnostics)
+        enriched.append(item)
+    return enriched
 
 
 def _line_of(source: str, pos: int) -> int:
@@ -52,7 +77,7 @@ def extract_python(path: Path) -> list[dict]:
             if doc:
                 sym["doc"] = doc.split("\n")[0][:80]
             symbols.append(sym)
-    return symbols
+    return _with_symbol_metadata(symbols, "ast", "python-ast", 0.95)
 
 
 # ── JavaScript / TypeScript / Vue ─────────────────────────────────────────────
@@ -101,7 +126,7 @@ def extract_js(path: Path) -> list[dict]:
                     "exported": True,
                 })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "javascript-regex", 0.70)
 
 
 # ── Go ────────────────────────────────────────────────────────────────────────
@@ -143,7 +168,7 @@ def extract_go(path: Path) -> list[dict]:
                     "exported": name[0].isupper(),
                 })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "go-regex", 0.75)
 
 
 # ── Java / Kotlin ─────────────────────────────────────────────────────────────
@@ -208,7 +233,8 @@ def extract_java(path: Path) -> list[dict]:
                 "exported": True,
             })
 
-    return symbols
+    extractor = "kotlin-regex" if is_kotlin else "java-regex"
+    return _with_symbol_metadata(symbols, "regex", extractor, 0.70)
 
 
 # ── Rust ─────────────────────────────────────────────────────────────────────
@@ -247,7 +273,7 @@ def extract_rust(path: Path) -> list[dict]:
                     "exported": m.group(0).startswith("pub"),
                 })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "rust-regex", 0.75)
 
 
 # ── PHP ───────────────────────────────────────────────────────────────────────
@@ -282,7 +308,7 @@ def extract_php(path: Path) -> list[dict]:
                     "exported": True,
                 })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "php-regex", 0.70)
 
 
 # ── Ruby ─────────────────────────────────────────────────────────────────────
@@ -317,7 +343,7 @@ def extract_ruby(path: Path) -> list[dict]:
                     "exported": True,
                 })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "ruby-regex", 0.70)
 
 
 # ── C# (Roslyn-first with regex fallback) ────────────────────────────────────
@@ -386,7 +412,7 @@ def _extract_csharp_roslyn(path: Path) -> list[dict] | None:
 def extract_csharp(path: Path) -> list[dict]:
     roslyn_symbols = _extract_csharp_roslyn(path)
     if roslyn_symbols is not None:
-        return roslyn_symbols
+        return _with_symbol_metadata(roslyn_symbols, "roslyn", "codeindex-csharp-symbols", 0.98)
     try:
         source = path.read_text(errors="replace")
     except OSError:
@@ -423,12 +449,12 @@ def extract_csharp(path: Path) -> list[dict]:
             "exported": "public" in mods.split(),
         })
 
-    return symbols
+    return _with_symbol_metadata(symbols, "regex", "csharp-regex", 0.70)
 
 
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 
-EXTRACTORS: dict[str, callable] = {
+EXTRACTORS: dict[str, Callable[[Path], list[dict]]] = {
     ".py":   extract_python,
     ".js":   extract_js,
     ".jsx":  extract_js,

--- a/codeindex/symbols.py
+++ b/codeindex/symbols.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 import json
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
+from codeindex import __version__
 from codeindex.analyzers.base import load_gitignore_patterns, is_ignored, is_skip_dir
-from codeindex.symbol_extractor import EXTRACTORS, extract_symbols
+from codeindex.symbol_extractor import EXTRACTORS, SYMBOL_SCHEMA_VERSION, extract_symbols
 
 SYMBOL_INDEX_FILENAME = "symbolindex.json"
 
@@ -14,6 +15,25 @@ _CLAUDE_START = "<!-- codeindex-symbols-start -->"
 _CLAUDE_END   = "<!-- codeindex-symbols-end -->"
 
 _SUPPORTED_EXTS = frozenset(EXTRACTORS.keys())
+
+_EXT_LANG = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".vue": "vue",
+    ".go": "go",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".rs": "rust",
+    ".php": "php",
+    ".rb": "ruby",
+    ".cs": "csharp",
+}
 
 _KIND_ABBR = {
     "function":  "fn",
@@ -42,6 +62,50 @@ def _collect_files(root: Path) -> list[Path]:
     return files
 
 
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _confidence_band(confidence: float) -> str:
+    if confidence >= 0.90:
+        return "high"
+    if confidence >= 0.70:
+        return "medium"
+    return "low"
+
+
+def _summarize_metadata(by_file: dict[str, list[dict]]) -> dict:
+    modes: dict[str, dict[str, int]] = {}
+    extractors: dict[str, int] = {}
+    bands = {"high": 0, "medium": 0, "low": 0}
+    confidence_total = 0.0
+    confidence_count = 0
+
+    for rel, symbols in by_file.items():
+        language = _EXT_LANG.get(Path(rel).suffix.lower(), "unknown")
+        language_modes = modes.setdefault(language, {})
+        for symbol in symbols:
+            mode = str(symbol.get("analysisMode", "unknown"))
+            language_modes[mode] = language_modes.get(mode, 0) + 1
+            extractor = str(symbol.get("extractor", "unknown"))
+            extractors[extractor] = extractors.get(extractor, 0) + 1
+            confidence = symbol.get("confidence")
+            if isinstance(confidence, (int, float)):
+                confidence_total += float(confidence)
+                confidence_count += 1
+                bands[_confidence_band(float(confidence))] += 1
+
+    average = round(confidence_total / confidence_count, 3) if confidence_count else None
+    return {
+        "analysisModes": modes,
+        "extractors": extractors,
+        "confidence": {
+            "average": average,
+            "bands": bands,
+        },
+    }
+
+
 def build_symbol_index(repo_path: str) -> dict:
     """Scan repo and return full symbol index dict."""
     root = Path(repo_path).resolve()
@@ -63,11 +127,19 @@ def build_symbol_index(repo_path: str) -> dict:
             entry["file"] = rel
             by_name.setdefault(sym["name"], []).append(entry)
 
+    metadata = _summarize_metadata(by_file)
+
     return {
+        "schemaVersion": SYMBOL_SCHEMA_VERSION,
         "meta": {
+            "schemaVersion": SYMBOL_SCHEMA_VERSION,
             "generated": str(date.today()),
+            "generatedAt": _utc_now(),
             "repo": root.name + "/",
             "total_symbols": total,
+            "toolVersion": __version__,
+            "diagnostics": [],
+            **metadata,
         },
         "symbols": by_name,
         "file_symbols": by_file,

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,64 @@
+# Troubleshooting
+
+## `symbolindex.json` Is Missing
+
+Run:
+
+```bash
+codeindex symbols <repo>
+```
+
+MCP `lookup_symbol` and `get_symbol_metadata` require this file unless a path is provided.
+
+You can check all generated artifacts with:
+
+```bash
+codeindex doctor <repo>
+```
+
+For PR or CI checks, run:
+
+```bash
+codeindex ci <repo> --base origin/main
+```
+
+Use `--strict` only after the repository has a stable threshold and the team agrees warnings should fail builds.
+
+## `codeindex.json` Is Missing
+
+Run:
+
+```bash
+codeindex analyze <repo>
+```
+
+Commands such as `impact`, `dependencies`, and `high-blast` need the dependency index.
+
+## C# Uses Regex Instead Of Roslyn
+
+C# symbols use `codeindex-csharp-symbols` when that executable is available on `PATH`. If it is missing, times out, returns invalid JSON, or exits nonzero, codeindex falls back to `csharp-regex` metadata.
+
+Check `symbolindex.json` entries for:
+
+```json
+{
+  "analysisMode": "regex",
+  "extractor": "csharp-regex",
+  "confidence": 0.7
+}
+```
+
+Fallback is useful, but it is not compiler-backed.
+
+## Generated Files Dirty The Worktree
+
+`codeindex analyze` and `codeindex symbols` write `codeindex.json` and `symbolindex.json` to the repo root by default. Use `--output` for temporary validation:
+
+```bash
+codeindex analyze . --output /tmp/codeindex.json
+codeindex symbols . --output /tmp/symbolindex.json
+```
+
+## MCP Tool Returns An Error
+
+Most MCP errors are missing index files or unresolved file paths. Build the required index first, then pass explicit `index_path` or `symbol_index_path` if the server process is not running from the repo root.

--- a/docs/reference/analyzer-modes.md
+++ b/docs/reference/analyzer-modes.md
@@ -1,0 +1,33 @@
+# Analyzer Modes
+
+Analyzer modes describe how a result was produced. They are not marketing labels; they are trust signals.
+
+| Mode | Meaning | Typical confidence |
+| ---- | ------- | ------------------ |
+| `ast` | Parsed by a structured language parser, such as Python `ast`. | High |
+| `roslyn` | Produced by Roslyn-backed C# tooling. | High |
+| `regex` | Produced by lexical or regular-expression heuristics. | Medium |
+| `heuristic` | Produced by broader static heuristics. | Medium |
+| `heuristic-fallback` | A required richer analyzer was unavailable and fallback was used. | Medium or low |
+| `partial` | The analyzer returned incomplete but useful data. | Low or medium |
+
+## Current Symbol Extractors
+
+| Language | Current extractor | Mode | Default confidence |
+| -------- | ----------------- | ---- | ------------------ |
+| Python | `python-ast` | `ast` | `0.95` |
+| C# with `codeindex-csharp-symbols` | `codeindex-csharp-symbols` | `roslyn` | `0.98` |
+| C# fallback | `csharp-regex` | `regex` | `0.70` |
+| JavaScript / TypeScript / Vue | `javascript-regex` | `regex` | `0.70` |
+| Go | `go-regex` | `regex` | `0.75` |
+| Java / Kotlin | `java-regex` / `kotlin-regex` | `regex` | `0.70` |
+| Rust | `rust-regex` | `regex` | `0.75` |
+| PHP | `php-regex` | `regex` | `0.70` |
+| Ruby | `ruby-regex` | `regex` | `0.70` |
+
+## Guidance For Agents
+
+- Prefer high-confidence results when choosing an edit target.
+- Treat medium-confidence results as navigation hints, then inspect the file before editing.
+- Never treat fallback metadata as equivalent to compiler-backed success.
+- When a requested symbol is missing, use dependency and blast-radius tools before broad file scanning.

--- a/docs/reference/codeindex-schema.md
+++ b/docs/reference/codeindex-schema.md
@@ -1,0 +1,50 @@
+# codeindex.json Schema
+
+`codeindex.json` is the dependency and blast-radius index. Schema metadata is additive and designed to help humans, agents, and CI decide whether results are fresh and trustworthy.
+
+## Top-Level Shape
+
+```json
+{
+  "schemaVersion": 1,
+  "meta": {},
+  "nodes": [],
+  "links": []
+}
+```
+
+## `meta`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `schemaVersion` | number | Schema version for the dependency index. |
+| `root` | string | Repository directory name with trailing `/`. |
+| `total_files` | number | Indexed file count. |
+| `total_loc` | number | Indexed lines of code. |
+| `languages` | array | Detected languages. |
+| `generatedAt` | string | UTC timestamp for freshness checks. |
+| `toolVersion` | string | `codeindex` package version that generated the index. |
+| `indexed` | boolean | Indicates the index was built by `codeindex.index.build`. |
+| `analysisModes` | object | Reserved for per-language analyzer mode summaries. |
+| `diagnostics` | array | Non-fatal issues discovered during analysis. |
+
+## Nodes
+
+Nodes describe source files, packages, services, schemas, and external imports. Existing fields remain stable: `id`, `type`, `language`, `layer`, `loc`, `imports`, `imported_by`, `direct_dependents`, `transitive_dependents`, and `blast_score`.
+
+When `codeindex symbols --inline` is used, nodes may also include a `symbols` array. Symbol entries follow the `symbolindex.json` symbol-entry contract, including `analysisMode`, `extractor`, and `confidence` when available.
+
+## Links
+
+Links describe dependency edges.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `source` | string | Dependent node id. |
+| `target` | string | Dependency node id. |
+| `weight` | number | Edge weight. |
+| `kind` | string | `imports`, `styles`, `depends`, `renders`, or another relationship kind. |
+
+## Scoring
+
+The foundation schema does not change blast-score math. `blast_score` remains `direct + (0.5 * transitive)`. Confidence is surfaced beside results first; confidence-aware scoring should be opt-in and benchmarked before it changes default behavior.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,0 +1,31 @@
+# MCP Tools
+
+`codeindex serve --mcp` exposes repository intelligence over JSON-RPC stdio.
+
+## Tools
+
+| Tool | Purpose | Metadata Notes |
+| ---- | ------- | -------------- |
+| `analyze_repo` | Build or refresh `codeindex.json`. | Returns file, LOC, and language summary. |
+| `get_impact` | Return blast-radius report for a file. | Uses the dependency index. |
+| `get_dependencies` | Return imports and imported-by for a file. | Useful before editing. |
+| `get_high_blast_files` | List risky files above a threshold. | Useful for planning and review. |
+| `build_symbol_index` | Build or refresh `symbolindex.json`. | Returns schema, analysis modes, confidence summary, and diagnostics when available. |
+| `lookup_symbol` | Find symbol definitions by exact name. | Returns provenance fields when available. |
+| `get_symbol_metadata` | Return symbol provenance and confidence only. | Use when an agent needs to decide whether a lookup is authoritative. |
+| `verify_repo_health` | Check generated index health. | Reports missing indexes, schema metadata, freshness, and diagnostics. |
+| `run_ci_check` | Run PR/CI preflight checks. | Combines repo health with changed-file blast-radius warnings. |
+
+## Agent Pattern
+
+1. Call `build_symbol_index` after clone or large refactors.
+2. Call `lookup_symbol` for exact symbol navigation.
+3. Check `analysisMode`, `extractor`, and `confidence` before trusting a result.
+4. Call `get_dependencies` and `get_impact` before editing high-blast files.
+5. Use `get_symbol_metadata` when a workflow needs provenance without full lookup formatting.
+6. Use `verify_repo_health` before relying on cached indexes in long-running agent sessions or CI.
+7. Use `run_ci_check` before handing off a PR or proposing high-risk changes.
+
+## Compatibility
+
+Tool additions are additive. Existing clients that only use the original six tools can keep operating. New fields in responses should be treated as optional by clients that do not require trust metadata.

--- a/docs/reference/symbolindex-schema.md
+++ b/docs/reference/symbolindex-schema.md
@@ -1,0 +1,63 @@
+# symbolindex.json Schema
+
+`symbolindex.json` is the lookup table used by `codeindex lookup`, MCP `lookup_symbol`, and optional `CLAUDE.md` injection. Schema fields are additive: older clients can ignore fields they do not understand.
+
+## Top-Level Shape
+
+```json
+{
+  "schemaVersion": 1,
+  "meta": {},
+  "symbols": {},
+  "file_symbols": {}
+}
+```
+
+## `meta`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `schemaVersion` | number | Schema version for this symbol index. |
+| `generated` | string | Backward-compatible date stamp, `YYYY-MM-DD`. |
+| `generatedAt` | string | UTC timestamp for freshness checks. |
+| `repo` | string | Repository directory name with trailing `/`. |
+| `total_symbols` | number | Total number of symbol entries. |
+| `toolVersion` | string | `codeindex` package version that generated the index. |
+| `analysisModes` | object | Per-language counts by extraction mode. |
+| `extractors` | object | Counts by extractor implementation. |
+| `confidence` | object | Average confidence and high/medium/low band counts. |
+| `diagnostics` | array | Non-fatal issues discovered while building the index. |
+
+## Symbol Entries
+
+Every entry keeps the legacy fields and adds provenance fields.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `name` | string | Symbol name. Present in `file_symbols`; map key in `symbols`. |
+| `file` | string | File path. Present in `symbols` entries. |
+| `line` | number | 1-based source line. |
+| `kind` | string | `function`, `class`, `struct`, `enum`, `interface`, `type`, `const`, or similar. |
+| `exported` | boolean | Whether the extractor considers the symbol public/exported. |
+| `methods` | array | Optional method summary for class-like symbols. |
+| `doc` | string | Optional short documentation summary. |
+| `analysisMode` | string | `ast`, `regex`, `roslyn`, or another documented mode. |
+| `extractor` | string | Extractor implementation name, such as `python-ast` or `csharp-regex`. |
+| `extractorVersion` | string | Extractor contract version. |
+| `confidence` | number | Approximate trust score from `0.0` to `1.0`. |
+| `schemaVersion` | number | Symbol entry schema version. |
+| `diagnostics` | array | Optional symbol-level issues. |
+
+## Confidence Bands
+
+Confidence values are intentionally coarse. Benchmark fixtures cover the current language paths and C# Roslyn/regex split so changes to extractor provenance or confidence bands show up as regression-test failures.
+
+| Band | Range | Meaning |
+| ---- | ----- | ------- |
+| `high` | `>= 0.90` | Parser or compiler-backed result. |
+| `medium` | `>= 0.70` and `< 0.90` | Heuristic or regex-backed result that is useful but approximate. |
+| `low` | `< 0.70` | Partial or uncertain result. |
+
+## Compatibility
+
+The original `generated`, `repo`, `total_symbols`, `symbols`, and `file_symbols` fields remain available. Integrations should treat new fields as optional unless they explicitly require schema version 1 metadata.

--- a/docs/workflows/ai-agent-workflows.md
+++ b/docs/workflows/ai-agent-workflows.md
@@ -1,0 +1,45 @@
+# AI Agent Workflows
+
+codeindex helps AI agents avoid broad repo scans by turning repository structure into explicit lookup and impact data. The trust metadata added to `symbolindex.json` lets agents decide whether a result is compiler/parser-backed or approximate.
+
+## Symbol Navigation
+
+Recommended flow:
+
+1. Build symbols with `codeindex symbols <repo>` or MCP `build_symbol_index`.
+2. Use `codeindex doctor <repo>` or MCP `verify_repo_health` to confirm indexes are present and fresh.
+3. Use MCP `lookup_symbol` for exact symbol lookup.
+4. Inspect `analysisMode`, `extractor`, and `confidence`.
+5. Open only the returned file and nearby lines.
+
+High-confidence examples include Python `ast` and C# `roslyn`. Regex-backed results are still useful, but agents should inspect the target file before editing.
+
+## Change Impact Before Editing
+
+Recommended flow:
+
+1. Use `get_dependencies` for a file's direct relationships.
+2. Use `get_impact` for blast-radius context.
+3. Prefer smaller, lower-blast edits when multiple designs are possible.
+4. For high-blast files, run focused tests and ask for review coverage.
+
+## Review And CI
+
+Teams can use codeindex outputs in CI or PR automation:
+
+- report high-blast files changed in a PR
+- warn when indexes are stale or missing
+- show whether key lookups were `ast`, `roslyn`, or `regex`
+- attach `codeindex impact` output to review comments
+
+Use `codeindex ci <repo> --base origin/main --json` or MCP `run_ci_check` to get a single machine-readable preflight report. Start with warnings. Make gates strict only after a repository has stable indexes and a documented threshold.
+
+## Prompt Pattern For Agents
+
+```text
+Before editing, use codeindex to find the symbol, inspect its confidence, and check the target file's blast radius. If confidence is medium or low, open the file and verify the result before changing code.
+```
+
+## Scope Boundaries
+
+Trust metadata improves all current languages, but it does not make every analyzer compiler-backed. C#/Roslyn is the first high-confidence external-tool lane. Deeper TypeScript, Go, Rust, Java/Kotlin, Razor, and framework-aware analysis should build on this same metadata contract.


### PR DESCRIPTION
## Summary

- Add additive schema, freshness, tool version, analyzer mode, extractor, and confidence metadata to generated indexes.
- Add per-symbol provenance/confidence metadata, including C# Roslyn-first extraction with regex fallback metadata.
- Add repo health and CI preflight surfaces through `codeindex doctor`, `codeindex ci`, and MCP tools `get_symbol_metadata`, `verify_repo_health`, and `run_ci_check`.
- Expand docs and regression coverage for schema metadata, analyzer modes, MCP tools, troubleshooting, AI-agent workflows, and curated multi-language fixtures.

## Validation

- `.venv/bin/python -m compileall codeindex benchmark`
- `.venv/bin/codeindex symbols .`
- `.venv/bin/python benchmark/test_symbol_extractor.py`
- `.venv/bin/python benchmark/test_schema_metadata.py`
- `.venv/bin/python benchmark/test_cli.py --repo . --codeindex .venv/bin/codeindex`
- `.venv/bin/python benchmark/test_mcp.py --repo . --codeindex .venv/bin/codeindex`
- `git diff --check`
- `test ! -f symbolindex.json`